### PR TITLE
fix typo in "Function arguments 2 or fewer ideally"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1107,7 +1107,7 @@ public void CreateMenu(string title, string body, string buttonText, bool cancel
 **Good:**
 
 ```csharp
-pubic class MenuConfig
+public class MenuConfig
 {
     public string Title { get; set; }
     public string Body { get; set; }


### PR DESCRIPTION
Hi, I think that I just found a typing mistake.

Thanks for your work,
Reading this was interesting :)