### PR TITLE
Corrected missuse of a variable in the DRY exemple part of SOLID

### DIFF
--- a/README.md
+++ b/README.md
@@ -2421,8 +2421,8 @@ public List<EmployeeData> ShowList(Employee employees)
     foreach (var employee in employees)
     {
         var expectedSalary = employees.CalculateExpectedSalary();
-        var experience = employees.GetExperience();
-        var githubLink = employees.GetGithubLink();
+        var experience = employee.GetExperience();
+        var githubLink = employee.GetGithubLink();
         var data =
         new[] {
             expectedSalary,

--- a/README.md
+++ b/README.md
@@ -2420,7 +2420,7 @@ public List<EmployeeData> ShowList(Employee employees)
 {
     foreach (var employee in employees)
     {
-        var expectedSalary = employees.CalculateExpectedSalary();
+        var expectedSalary = employee.CalculateExpectedSalary();
         var experience = employee.GetExperience();
         var githubLink = employee.GetGithubLink();
         var data =


### PR DESCRIPTION
Was using "employees" instead of "employee"