### PR TITLE
Changing parameter for RenderLargeRectangles

### DIFF
--- a/README.md
+++ b/README.md
@@ -2141,7 +2141,7 @@ class Square : ShapeBase
     }
 }
 
-Drawable RenderLargeRectangles(Rectangle rectangles)
+Drawable RenderLargeRectangles(Rectangle[] rectangles)
 {
     foreach (rectangle in rectangles)
     {


### PR DESCRIPTION
Changed Rectangle to Rectangle[] in Good example for Liskov Substitution Principle (LSP).