### PR TITLE
fix typo "is an worker"

### DIFF
--- a/README.md
+++ b/README.md
@@ -2214,7 +2214,7 @@ public class Robot : IEmployee
 
 **Good:**
 
-Not every worker is an employee, but every employee is an worker.
+Not every worker is an employee, but every employee is a worker.
 
 ```csharp
 public interface IWorkable


### PR DESCRIPTION
Fix typo "is an worker" in Interface Segregation Principle (ISP) section